### PR TITLE
chore: Running 'go mod download' should catch any inconsistencies in checksums

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -57,16 +57,6 @@ jobs:
         if: inputs.go-private != ''
         run: git config --global url."https://${{ secrets.gh_username }}:${{ secrets.gh_token }}@github.com".insteadOf "https://github.com"
 
-      - name: Check go mod tidy
-        run: |
-          go mod tidy
-          if git diff --exit-code go.mod go.sum; then
-            echo "go.mod and go.sum are tidy."
-          else
-            echo "::error go.mod or go.sum are not tidy. Please run 'go mod tidy'."
-            exit 1
-          fi
-
       - name: Install Go dependencies
         run: |
           go mod download


### PR DESCRIPTION
Running 'go mod tidy' should not be necessary as 'go mod download' should check the downloads against the 'go.sum' checksums