### PR TITLE
chore: Only do gorelease config check on CI

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -81,17 +81,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          install-only: true
-
-      - name: Run GoReleaser healthcheck
-        run: goreleaser healthcheck
-
-      - name: Check GoReleaser config
-        run: goreleaser check
-
-      - name: Run GoReleaser dry-run
-        if: inputs.run-release-test
-        run: goreleaser release --snapshot --skip=publish --clean
+          args: check
 
   vuln-scan:
     runs-on: ubuntu-latest
@@ -109,12 +99,16 @@ jobs:
           ignore-unfixed: true
           vuln-type: "library"
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Setup private repository access
         if: inputs.go-private != ''
         run: git config --global url."https://${{ secrets.gh_username }}:${{ secrets.gh_token }}@github.com".insteadOf "https://github.com"
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          repo-checkout: false
-          go-version-file: go.mod
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck -format text ./...


### PR DESCRIPTION
- No dry-run of goreleaser in CI pipeline
- Inline the run of `govulncheck` the action does not seem very stable

Fixes #15 