### PR TITLE
fix: require v2.1.0 for golangci-lint

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.1
 
       - name: Go Compile and Test
         run: go test -cover -v ./...


### PR DESCRIPTION
Fails otherwise: https://github.com/neticdk/go-common/actions/runs/14966627918/job/42037914513#step:7:25